### PR TITLE
refactor: remove rag_service shim and update imports

### DIFF
--- a/rag_demo/app/app/api/debug_router.py
+++ b/rag_demo/app/app/api/debug_router.py
@@ -7,7 +7,7 @@ import os
 
 from ..services.retrieval_service import retrieve as svc_retrieve
 from ..services.eval_service import evaluate_hit as svc_evaluate_hit
-from ..services.rag_service import RagService
+from ..services.rag import RagService
 from ..infra.llm.provider import get_chat
 from ..configure import config
 

--- a/rag_demo/app/app/api/query_router.py
+++ b/rag_demo/app/app/api/query_router.py
@@ -1,7 +1,7 @@
 # app/app/api/query_router.py
 from fastapi import APIRouter, Query
 from ..domain.models.query_model import QueryRequest, QueryResponse, RAGQueryResponse
-from ..services.rag_service import RagService
+from ..services.rag import RagService
 
 router = APIRouter(prefix="/rag", tags=["rag"])
 

--- a/rag_demo/app/app/api/rag_router.py
+++ b/rag_demo/app/app/api/rag_router.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from typing import Optional
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
-from app.app.services.rag_service import RagService
+from app.app.services.rag import RagService
 from app.app.domain.models.query_model import QueryRequest, RAGQueryResponse  # ← 네 모델 사용
 
 router = APIRouter(prefix="/rag", tags=["rag"])

--- a/rag_demo/app/app/domain/embeddings.py
+++ b/rag_demo/app/app/domain/embeddings.py
@@ -6,7 +6,7 @@ import numpy as np
 import sys as _sys
 # 너의 프로젝트에서 쓰일 수 있는 모든 경로 별칭을 통일
 for _alias in (
-    "app.app.domain.embeddings",  # rag_service가 쓰는 경로
+    "app.app.domain.embeddings",  # RagService가 쓰는 경로
     "app.domain.embeddings",
 ):
     if _alias != __name__:

--- a/rag_demo/app/app/scripts/rag_ab_test.py
+++ b/rag_demo/app/app/scripts/rag_ab_test.py
@@ -4,7 +4,7 @@ import os, json, time, argparse, csv, itertools, random, math, contextlib
 from pathlib import Path
 from typing import Dict, Any, List, Tuple
 
-from app.app.services.rag_service import RagService
+from app.app.services.rag import RagService
 from app.app.metrics.quality import (
     keys_from_docs, hit_at_k, recall_at_k, dup_rate, p_percentile
 )

--- a/rag_demo/app/app/scripts/rag_optuna_tune.py
+++ b/rag_demo/app/app/scripts/rag_optuna_tune.py
@@ -6,7 +6,7 @@ from typing import Dict, Any, List, Tuple
 
 import optuna  # pip install optuna
 
-from app.app.services.rag_service import RagService
+from app.app.services.rag import RagService
 from app.app.metrics.quality import (
     keys_from_docs, hit_at_k, recall_at_k, dup_rate, p_percentile
 )

--- a/rag_demo/app/app/services/rag_service.py
+++ b/rag_demo/app/app/services/rag_service.py
@@ -1,6 +1,0 @@
-"""Backward compatible import for RagService."""
-
-from .rag.service import RagService
-
-__all__ = ["RagService"]
-


### PR DESCRIPTION
## Summary
- drop backwards-compatibility rag_service wrapper
- update routers and scripts to import RagService from services.rag
- clarify RagService reference in embeddings module

## Testing
- `python -m py_compile rag_demo/app/app/api/query_router.py rag_demo/app/app/api/debug_router.py rag_demo/app/app/api/rag_router.py rag_demo/app/app/domain/embeddings.py rag_demo/app/app/scripts/rag_optuna_tune.py rag_demo/app/app/scripts/rag_ab_test.py`
- `pytest` *(fails: No module named 'llama_cpp')*


------
https://chatgpt.com/codex/tasks/task_e_68bfa53fdd2083258f0b91ab605459bf